### PR TITLE
adb over wifi: add eng build filter

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -162,9 +162,11 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.data.qmi.adb_logmask=0
 
-# ADBoverWIFI
+# configure adb over wifi only on the eng build
+ifneq (,$(filter eng, $(TARGET_BUILD_VARIANT)))
 PRODUCT_PROPERTY_OVERRIDES += \
     service.adb.tcp.port=5555
+endif
 
 # Enable MultiWindow
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
add filter so that adb over wifi is configured only for the eng build

Signed-off-by: Alin Jerpelea <alin.jerpelea@sonymobile.com>